### PR TITLE
Dedup predictions and gold answers before calculating f1

### DIFF
--- a/eval/simple_eval.py
+++ b/eval/simple_eval.py
@@ -43,7 +43,6 @@ def f1_emnlp2020(
         return (1.0, 0.0, 0.0)
 
     predictions = list(set(predictions))
-    gold = list(set(gold))
     
     # Compute precision score based on best gold match for each prediction
     tp = 0.0  # true positive score

--- a/eval/simple_eval.py
+++ b/eval/simple_eval.py
@@ -42,6 +42,9 @@ def f1_emnlp2020(
     if len(predictions) == 0:
         return (1.0, 0.0, 0.0)
 
+    predictions = list(set(predictions))
+    gold = list(set(gold))
+    
     # Compute precision score based on best gold match for each prediction
     tp = 0.0  # true positive score
     for p in predictions:

--- a/training/gen_ans_to_list.py
+++ b/training/gen_ans_to_list.py
@@ -55,7 +55,7 @@ def accept_answer(answer, keywords=['of', 'was', 'afterwards', 'before']):
 def ans_to_list(a, state_change_seps):
     answers = []
     for scsep in state_change_seps:
-        if a.count(scsep) > 1:
+        if a.count(scsep) > 0:
             answers = a.split(scsep)
             return filter_answers(answers)
     # if no separator was found or one sep was found.


### PR DESCRIPTION
I observe that generative models sometimes repeat the same state changes multiple times.

In the current codes, the precision of repeated state changes will be computed multiple times, which will make the final accuracy and f1 score higher. It's not very reasonable.

In this pull request I dedup the predictions (as well as gold answers) before calculating f1. F1 will slightly drop by 0.1-0.2 points.